### PR TITLE
Standardize naming to 'Speedrun Ethereum'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # 💻 BuidlGuidl Workshops
-Funding BuidlGuidl Workshops members for providing high-impact SpeedRunEthereum and Scaffold-ETH demonstrations, workshops, and hackathons!
+Funding BuidlGuidl Workshops members for providing high-impact Speedrun Ethereum and Scaffold-ETH demonstrations, workshops, and hackathons!

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -14,12 +14,12 @@ export const Header = () => (
       <link rel="icon" type="image/png" sizes="32x32" href="/favicon.png" />
       <meta
         name="description"
-        content="Funding BuidlGuidl members for providing high-impact SpeedRunEthereum and Scaffold-ETH demonstrations, workshops, and hackathons"
+        content="Funding BuidlGuidl members for providing high-impact Speedrun Ethereum and Scaffold-ETH demonstrations, workshops, and hackathons"
       />
       <meta property="og:title" content="Workshops" />
       <meta
         property="og:description"
-        content="funding BuidlGuidl members for providing high-impact SpeedRunEthereum and Scaffold-ETH demonstrations, workshops, and hackathons"
+        content="funding BuidlGuidl members for providing high-impact Speedrun Ethereum and Scaffold-ETH demonstrations, workshops, and hackathons"
       />
       <meta name="twitter:card" content="summary_large_image" />
       <meta property="og:image" content="https://workshops.buidlguidl.com/thumbnail.png" />

--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -14,7 +14,7 @@ const Home: NextPage = () => {
             <Link href="/members" className="link link-primary">
               Workshops Members
             </Link>{" "}
-            for providing high-impact SpeedRunEthereum and Scaffold-ETH demonstrations, workshops, and hackathons
+            for providing high-impact Speedrun Ethereum and Scaffold-ETH demonstrations, workshops, and hackathons
           </p>
           {/* <p>
             <

--- a/packages/nextjs/pages/projects.tsx
+++ b/packages/nextjs/pages/projects.tsx
@@ -14,7 +14,7 @@ const projects = [
     github: "https://github.com/scaffold-eth/scaffold-eth-2",
   },
   {
-    name: "SpeedRunEthereum",
+    name: "Speedrun Ethereum",
     description: "A platform to learn how to build on Ethereum; the superpowers and the gotchas.",
     link: "https://speedrunethereum.com",
     github: "https://github.com/BuidlGuidl/SpeedRunEthereum",


### PR DESCRIPTION
Replace inconsistent variations (SpeedRunEthereum, SpeedRun Ethereum, Speed Run Ethereum) with the standardized form 'Speedrun Ethereum'.

Preserved:
- speedrunethereum.com domain
- Repository URLs
- Lowercase references in links